### PR TITLE
fix plugins with no code-env fails to install

### DIFF
--- a/dku_plugin_test_utils/pytest_plugin/plugin.py
+++ b/dku_plugin_test_utils/pytest_plugin/plugin.py
@@ -163,24 +163,26 @@ def plugin(dss_clients):
         plugin_settings = uploaded_plugin.get_settings()
         raw_plugin_settings = plugin_settings.get_raw()
 
-        if "codeEnvName" in raw_plugin_settings and len(raw_plugin_settings["codeEnvName"]) != 0:
-            logger.debug("Code env [{code_env_name}] is already associated to [{plugin_id}] on [{dss_target}], deleting it".format(code_env_name=raw_plugin_settings["codeEnvName"], 
-                                                                                                                                   plugin_id=info["id"], 
-                                                                                                                                   dss_target=target))
+        # install (or reinstall) code-env only if plugin has a specific code-env defined (not using DSS built-in):
+        if PluginInfo().plugin_codenv_metadata is not None:
+            if "codeEnvName" in raw_plugin_settings and len(raw_plugin_settings["codeEnvName"]) != 0:
+                logger.debug("Code env [{code_env_name}] is already associated to [{plugin_id}] on [{dss_target}], deleting it".format(code_env_name=raw_plugin_settings["codeEnvName"],
+                                                                                                                                       plugin_id=info["id"],
+                                                                                                                                       dss_target=target))
 
-            code_env_list = admin_client.list_code_envs()
-            code_env_info = list(filter(lambda x: x["envName"] == raw_plugin_settings["codeEnvName"], code_env_list))
-            if code_env_info:
-                code_env_info = code_env_info[0]
-                code_env = admin_client.get_code_env(code_env_info["envLang"], code_env_info["envName"])
-                code_env.delete()
-            logger.debug("Code env [{code_env_name}] is deleted. Creating it again and associating it back to [{plugin_id}] on [{dss_target}]".format(code_env_name=raw_plugin_settings["codeEnvName"],
-                                                                                                                                                      plugin_id=info["id"],
-                                                                                                                                                      dss_target=target))
-            _install_code_env(target, info, plugin_settings, uploaded_plugin)
-        else:
-            logger.debug("No code env is associated to [{plugin_id}] on [{dss_target}], creating it".format(plugin_id=info["id"], dss_target=target))
-            _install_code_env(target, info, plugin_settings, uploaded_plugin)
+                code_env_list = admin_client.list_code_envs()
+                code_env_info = list(filter(lambda x: x["envName"] == raw_plugin_settings["codeEnvName"], code_env_list))
+                if code_env_info:
+                    code_env_info = code_env_info[0]
+                    code_env = admin_client.get_code_env(code_env_info["envLang"], code_env_info["envName"])
+                    code_env.delete()
+                logger.debug("Code env [{code_env_name}] is deleted. Creating it again and associating it back to [{plugin_id}] on [{dss_target}]".format(code_env_name=raw_plugin_settings["codeEnvName"],
+                                                                                                                                                          plugin_id=info["id"],
+                                                                                                                                                          dss_target=target))
+                _install_code_env(target, info, plugin_settings, uploaded_plugin)
+            else:
+                logger.debug("No code env is associated to [{plugin_id}] on [{dss_target}], creating it".format(plugin_id=info["id"], dss_target=target))
+                _install_code_env(target, info, plugin_settings, uploaded_plugin)
 
 
 def _install_code_env(target, plugin_info, plugin_settings, uploaded_plugin):

--- a/dku_plugin_test_utils/run_config/config_parser.py
+++ b/dku_plugin_test_utils/run_config/config_parser.py
@@ -107,19 +107,19 @@ class PluginInfo(object):
             with open('code-env/python/desc.json') as json_file:
                 self._code_env_info = json.load(json_file)
 
-        python_interpretors_to_use = None
-        if "acceptedPythonInterpreters" in self._code_env_info and len(self._code_env_info["acceptedPythonInterpreters"]) > 0:
-            _envs = self._code_env_info["acceptedPythonInterpreters"]
-            if all(map(lambda x: "PYTHON3" in x, _envs)):
-                python_interpretors_to_use = _envs  # All interpretor are python3 so taking any should do the trick
-            else:
-                # We have a mix of python2 and python3 or just python2
-                if all(map(lambda x: "PYTHON2" in x, _envs)):
-                    python_interpretors_to_use = _envs   # All interpretor are python2 so taking any should do the trick
+            python_interpretors_to_use = None
+            if "acceptedPythonInterpreters" in self._code_env_info and len(self._code_env_info["acceptedPythonInterpreters"]) > 0:
+                _envs = self._code_env_info["acceptedPythonInterpreters"]
+                if all(map(lambda x: "PYTHON3" in x, _envs)):
+                    python_interpretors_to_use = _envs  # All interpretor are python3 so taking any should do the trick
                 else:
-                    python_interpretors_to_use = list(filter(lambda x: "PYTHON2" in x, _envs))  # Filtering out python2, and taking any python3 interpretor version.
+                    # We have a mix of python2 and python3 or just python2
+                    if all(map(lambda x: "PYTHON2" in x, _envs)):
+                        python_interpretors_to_use = _envs   # All interpretor are python2 so taking any should do the trick
+                    else:
+                        python_interpretors_to_use = list(filter(lambda x: "PYTHON2" in x, _envs))  # Filtering out python2, and taking any python3 interpretor version.
 
-            self._plugin_metadata.update({"python_interpreter": python_interpretors_to_use})
+                self._plugin_metadata.update({"python_interpreter": python_interpretors_to_use})
 
     @property
     def plugin_metadata(self):

--- a/dku_plugin_test_utils/run_config/config_parser.py
+++ b/dku_plugin_test_utils/run_config/config_parser.py
@@ -97,12 +97,15 @@ class PluginInfo(object):
         self._initialized = True
 
         self._plugin_metadata = None
-        self._code_env_info = None
         with open('plugin.json') as json_file:
             self._plugin_metadata = json.load(json_file)
 
-        with open('code-env/python/desc.json') as json_file:
-            self._code_env_info = json.load(json_file)
+        self._code_env_info = None
+        # Some plugins don't have a specific code-env defined (they use DSS built-in code-env instead).
+        # for those, code-env desc.json will not exist:
+        if os.path.isfile('code-env/python/desc.json'):
+            with open('code-env/python/desc.json') as json_file:
+                self._code_env_info = json.load(json_file)
 
         python_interpretors_to_use = None
         if "acceptedPythonInterpreters" in self._code_env_info and len(self._code_env_info["acceptedPythonInterpreters"]) > 0:
@@ -110,7 +113,7 @@ class PluginInfo(object):
             if all(map(lambda x: "PYTHON3" in x, _envs)):
                 python_interpretors_to_use = _envs  # All interpretor are python3 so taking any should do the trick
             else:
-                # We have a mix of python2 and python3 or just python2 
+                # We have a mix of python2 and python3 or just python2
                 if all(map(lambda x: "PYTHON2" in x, _envs)):
                     python_interpretors_to_use = _envs   # All interpretor are python2 so taking any should do the trick
                 else:
@@ -132,4 +135,4 @@ class PluginInfo(object):
         Returns:
             dict: The python dict representing the code env metadata
         """
-        return self._plugin_metadata
+        return self._code_env_info


### PR DESCRIPTION
This fix case when plugin do not have a code-env/ dir because they just need to use DSS built-in code-env.

needed for plugin https://github.com/dataiku/dss-plugin-image-annotations-to-dataset